### PR TITLE
Fix: Remove limited ES6 usage

### DIFF
--- a/lazy-imports.html
+++ b/lazy-imports.html
@@ -41,11 +41,11 @@ Declarative lazy imports
       }
       var groupAttribute;
       if (group) {
-        groupAttribute = `[group=${group}]`;
+        groupAttribute = '[group=' + group + ']';
       } else {
         groupAttribute = 'not([group])';
       }
-      var query = `link${groupAttribute}[rel='lazy-import'][href]:not([href=""])`
+      var query = 'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=""])';
       var imports = fromElement.querySelectorAll(query);
       var promises = [];
       for (var i = 0; i < imports.length; i++) {


### PR DESCRIPTION
Usage of ES6 String literals prevents users from using it without some kind of transpiler. Fixes #14 #12 