### PR TITLE
Fix: Promises reject on failure

### DIFF
--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -12,56 +12,72 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    var __loadedImports = {};
+    var __importPromises = new Map();
 
-    Polymer.__importLazyGroup = function(callingElement, group, fromElement) {
-      if (!fromElement) {
-        fromElement = Polymer.DomModule.import(callingElement.localName);
-      }
-
-      var groupAttribute = group ? '[group=' + group + ']' : ':not([group])';
-      var query = 'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
-      var imports = fromElement.querySelectorAll(query);
+    /**
+     * Calls `Polymer.Base.importHref` for each `<link rel="lazy-import"` in
+     * the `dom-module` where the calling element is defined, where the
+     * "group" attribute matches the provided "group". If no group is
+     * provided, Lazy HTML Imports with no group will be imported.
+     *
+     * `importHref` is only called once per globally-unique URL.
+     *
+     * @param {HTMLElement} fromElement The element to search for lazy imports
+     *                                  within.
+     * @param {string=} group The group attribute to filter on.
+     * @param {object=} options Accepts a retry flag which will force a
+     *                          retry of a previously failed import.
+     * @return {Promise}
+     */
+    Polymer.__importLazyGroup = function(fromElement, group, options) {
       var importStatuses = {loaded: [], failed: []};
-
-      if (!imports.length) {
+      var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
+      var query =
+        'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
+      var links =
+        Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
+      if (links.length < 1) {
         return Promise.reject(importStatuses);
       }
-
-      var promises = [];
-      for (var i = 0; i < imports.length; i++) {
-        promises.push(new Promise(function(resolve) {
-          var href = imports[i].getAttribute('href');
-          var onLoad = function() {
-            resolve({loaded: href});
-          };
-          var onFailure = function() {
-            resolve({failed: href});
-          };
-          var resolved = callingElement.resolveUrl(href);
-          if (!__loadedImports[resolved]) {
-            __loadedImports[resolved] = true;
-            var importHref = Polymer.importHref || callingElement.importHref;
-            importHref(resolved, onLoad, onFailure);
-          } else {
-            resolve({loaded: href});
+      var requestPromises = Array.from(links).map(function(link) {
+        var promise;
+        var href = link.getAttribute('href');
+        var resolvedUrl = fromElement.resolveUrl(href);
+        var requestImport = function() {
+          return new Promise(function(resolve, reject) {
+            var importHref = Polymer.importHref || fromElement.importHref;
+            importHref(resolvedUrl, resolve, reject);
+          });
+        };
+        if (__importPromises.has(resolvedUrl)) {
+          promise = __importPromises.get(resolvedUrl);
+          if (options && options.retry) {
+            promise = promise.catch(requestImport);
           }
-        }));
-      }
-      return Promise.all(promises).then(function(importRequests) {
+        } else {
+          promise = requestImport();
+        }
+        __importPromises.set(resolvedUrl, promise);
+        return promise.then(
+          function onLoad() {
+            return {loaded: href};
+          },
+          function onFail() {
+            return {failed: href};
+          }
+        );
+      });
+      return Promise.all(requestPromises).then(function(importRequests) {
         importStatuses = importRequests.reduce(function(requests, nextRequest) {
           if (nextRequest.loaded) {
             requests.loaded.push(nextRequest.loaded);
           }
-
           if (nextRequest.failed) {
             requests.failed.push(nextRequest.failed);
           }
-
           return requests;
         }, importStatuses);
-
-        if (importStatuses.failed.length) {
+        if (importStatuses.failed.length > 0) {
           return Promise.reject(importStatuses);
         } else {
           return importStatuses;

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -39,7 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
 
       if (links.length < 1) {
-        return Promise.reject(new Error('No imports found in the specified group.'));
+        return Promise.reject(
+          new Error('No imports found in the specified group.'));
       }
 
       var requestPromises = Array.from(links).map(function(link) {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
 
       if (links.length < 1) {
-        return Promise.reject(importStatuses);
+        return Promise.reject(new Error('No imports found in the specified group.'));
       }
 
       var requestPromises = Array.from(links).map(function(link) {
@@ -89,7 +89,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, importStatuses);
 
         if (importStatuses.failed.length > 0) {
-          return Promise.reject(importStatuses);
+          const error = new Error('One or more imports failed to load.');
+          error.importStatuses = importStatuses;
+          throw error;
         } else {
           return importStatuses;
         }

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -34,21 +34,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
       var query =
         'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
+
       var links =
         Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
+
       if (links.length < 1) {
         return Promise.reject(importStatuses);
       }
+
       var requestPromises = Array.from(links).map(function(link) {
         var promise;
         var href = link.getAttribute('href');
         var resolvedUrl = fromElement.resolveUrl(href);
+
         var requestImport = function() {
           return new Promise(function(resolve, reject) {
             var importHref = Polymer.importHref || fromElement.importHref;
             importHref(resolvedUrl, resolve, reject);
           });
         };
+
         if (__importPromises.has(resolvedUrl)) {
           promise = __importPromises.get(resolvedUrl);
           if (options && options.retry) {
@@ -57,7 +62,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           promise = requestImport();
         }
+
         __importPromises.set(resolvedUrl, promise);
+
         return promise.then(
           function onLoad() {
             return {loaded: href};
@@ -67,16 +74,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         );
       });
+
       return Promise.all(requestPromises).then(function(importRequests) {
         importStatuses = importRequests.reduce(function(requests, nextRequest) {
           if (nextRequest.loaded) {
             requests.loaded.push(nextRequest.loaded);
           }
+
           if (nextRequest.failed) {
             requests.failed.push(nextRequest.failed);
           }
+
           return requests;
         }, importStatuses);
+
         if (importStatuses.failed.length > 0) {
           return Promise.reject(importStatuses);
         } else {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -9,8 +9,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <script>
-  'use strict';
   (function() {
+    'use strict';
+
     var __loadedImports = {};
 
     Polymer.__importLazyGroup = function(callingElement, group, fromElement) {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -9,74 +9,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <script>
+  'use strict';
   (function() {
-    'use strict';
+    var __loadedImports = {};
 
-    var __importPromises = new Map();
+    Polymer.__importLazyGroup = function(callingElement, group, fromElement) {
+      if (!fromElement) {
+        fromElement = Polymer.DomModule.import(callingElement.localName);
+      }
 
-    /**
-     * Calls `Polymer.Base.importHref` for each `<link rel="lazy-import"` in
-     * the `dom-module` where the calling element is defined, where the
-     * "group" attribute matches the provided "group". If no group is
-     * provided, Lazy HTML Imports with no group will be imported.
-     *
-     * `importHref` is only called once per globally-unique URL.
-     *
-     * @param {HTMLElement} fromElement The element to search for lazy imports
-     *                                  within.
-     * @param {string=} group The group attribute to filter on.
-     * @param {object=} options Accepts a retry flag which will force a
-     *                          retry of a previously failed import.
-     * @return {Promise}
-     */
-    Polymer.__importLazyGroup = function(fromElement, group, options) {
+      var groupAttribute = group ? '[group=' + group + ']' : ':not([group])';
+      var query = 'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
+      var imports = fromElement.querySelectorAll(query);
       var importStatuses = {loaded: [], failed: []};
-      var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
-      var query =
-        'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
 
-      var links =
-        Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
+      if (!imports.length) {
+        return Promise.reject(importStatuses);
+      }
 
-        if (links.length < 1) {
-          return Promise.resolve(importStatuses);
-        }
-
-        var requestPromises = Array.from(links).map(function(link) {
-          var promise;
-          var href = link.getAttribute('href');
-          var resolvedUrl = fromElement.resolveUrl(href);
-
-          var requestImport = function() {
-            return new Promise(function(resolve, reject) {
-            var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject);
-          });
-        };
-
-        if (__importPromises.has(resolvedUrl)) {
-          promise = __importPromises.get(resolvedUrl);
-          if (options && options.retry) {
-            promise = promise.catch(requestImport);
+      var promises = [];
+      for (var i = 0; i < imports.length; i++) {
+        promises.push(new Promise(function(resolve) {
+          var href = imports[i].getAttribute('href');
+          var onLoad = function() {
+            resolve({loaded: href});
+          };
+          var onFailure = function() {
+            resolve({failed: href});
+          };
+          var resolved = callingElement.resolveUrl(href);
+          if (!__loadedImports[resolved]) {
+            __loadedImports[resolved] = true;
+            var importHref = Polymer.importHref || callingElement.importHref;
+            importHref(resolved, onLoad, onFailure);
+          } else {
+            resolve({loaded: href});
           }
-        } else {
-          promise = requestImport();
-        }
-
-        __importPromises.set(resolvedUrl, promise);
-
-        return promise.then(
-          function onLoad() {
-            return {loaded: href};
-          },
-          function onFail() {
-            return {failed: href};
-          }
-        );
-      });
-
-      return Promise.all(requestPromises).then(function(importRequests) {
-        return importRequests.reduce(function(requests, nextRequest) {
+        }));
+      }
+      return Promise.all(promises).then(function(importRequests) {
+        importStatuses = importRequests.reduce(function(requests, nextRequest) {
           if (nextRequest.loaded) {
             requests.loaded.push(nextRequest.loaded);
           }
@@ -87,6 +59,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           return requests;
         }, importStatuses);
+
+        if (importStatuses.failed.length) {
+          return Promise.reject(importStatuses);
+        } else {
+          return importStatuses;
+        }
       });
     };
   })();

--- a/test/1.x/lazy-imports_test.html
+++ b/test/1.x/lazy-imports_test.html
@@ -51,14 +51,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('Still resolves after second attempt to import', function(done) {
         var called = false;
         var testEnvironment = initTest();
+        sinon.stub(
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve) {
+            resolve();
+          });
         testEnvironment.element.addEventListener('import-loaded', function() {
           if (called) {
-            assert.isTrue(testEnvironment.lazy.importLoaded);
+            (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
             done();
           } else {
-            called = true; // mark it so we can check for a second firing
+            called = true; // Mark it so we can check for a second firing
             testEnvironment.button.click();
           }
+        });
+        testEnvironment.element.addEventListener('import-failed', function() {
+          throw new Error('fail');
         });
         testEnvironment.button.click();
       });
@@ -67,19 +74,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var testEnvironment = initTest();
         testEnvironment.element.group = 'lazyFail';
 
-        var stubbedImport = sinon.stub(
-          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', (url, resolve, reject) => reject());
+        sinon.stub(
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject) {
+            reject();
+          });
 
-        testEnvironment.element.addEventListener('import-loaded', function() {
+        testEnvironment.element.addEventListener('import-failed', function() {
           if (called) {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
+            (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
             done();
           } else {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
-              (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
             called = true; // mark it so we can check for a second firing
             testEnvironment.button.click();
           }
+        });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          throw new Error('fail');
         });
         testEnvironment.button.click();
       });
@@ -89,21 +99,60 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         testEnvironment.element.group = 'lazyFail';
         testEnvironment.element.retry = true;
 
-        var stubbedImport = sinon.stub(
-          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', (url, resolve, reject) => reject());
+        sinon.stub(
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject) {
+            reject();
+          });
 
-        testEnvironment.element.addEventListener('import-loaded', function() {
+        testEnvironment.element.addEventListener('import-failed', function() {
           if (called) {
-            assert.isTrue(testEnvironment.lazyFail.importLoaded);
-            done();
+            throw new Error('fail');
           } else {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
             (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
+            sinon.stub(
+              (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve) {
+                resolve();
+              });
             called = true; // mark it so we can check for a second firing
             testEnvironment.button.click();
           }
         });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
+          done();
+        });
         testEnvironment.button.click();
+      });
+      test('Resolves correctly if request is currently in-flight when another request is made', function(done) {
+        var called = false;
+        var resolve;
+        var promise = new Promise(function(res) {
+          resolve = res;
+        });
+        var testEnvironment = initTest();
+
+        sinon.stub(
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, res) {
+            promise.then(res);
+          });
+
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          if (called) {
+            (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
+            done();
+          }
+          called = true; // Mark call and wait for second promise event
+        });
+        testEnvironment.element.addEventListener('import-failed', function() {
+          throw new Error('fail');
+        });
+
+        testEnvironment.button.click();
+        assert.isFalse(called);
+        testEnvironment.button.click();
+        assert.isFalse(called);
+
+        resolve();
       });
       test('Does not throw an exception when importing number based groups', function() {
         var testEnvironment = initTest();

--- a/test/1.x/lazy-imports_test.html
+++ b/test/1.x/lazy-imports_test.html
@@ -39,6 +39,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
     suite('lazy-imports', function() {
+      test('Rejects with Error if no imports found in group', function(done) {
+        var testEnvironment = initTest();
+        testEnvironment.element.group = 'nonexistent';
+        testEnvironment.element.addEventListener('import-failed', function(e) {
+          assert.instanceOf(e.detail, Error);
+          assert.equal(e.detail.message, 'No imports found in the specified group.');
+          done();
+        });
+        testEnvironment.button.click();
+      });
       test('After import triggered, element upgrades', function(done) {
         var testEnvironment = initTest();
         assert.isUndefined(testEnvironment.lazy.importLoaded);
@@ -79,8 +89,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             reject();
           });
 
-        testEnvironment.element.addEventListener('import-failed', function() {
+        testEnvironment.element.addEventListener('import-failed', function(e) {
           if (called) {
+            assert.instanceOf(e.detail, Error);
+            assert.equal(e.detail.message, 'One or more imports failed to load.');
+            assert.deepEqual(e.detail.importStatuses, {loaded: [], failed: ['lazy-fail-element.html']});
             (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
             done();
           } else {

--- a/test/1.x/upgrade-button.html
+++ b/test/1.x/upgrade-button.html
@@ -37,10 +37,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       buttonPressed: function(e) {
-        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(function(results) {
-          console.log(results);
-          this.fire('import-loaded', results);
-        }.bind(this));
+        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(
+          function(results) {
+            console.log(results);
+            this.fire('import-loaded', results);
+          }.bind(this),
+          function(results) {
+            console.log(results);
+            this.fire('import-failed', results);
+          }.bind(this)
+        );
       },
     });
   </script>

--- a/test/2.0/lazy-imports_test.html
+++ b/test/2.0/lazy-imports_test.html
@@ -54,6 +54,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       });
 
+      test('Rejects with Error if no imports found in group', function(done) {
+        var testEnvironment = initTest();
+        testEnvironment.element.group = 'nonexistent';
+        testEnvironment.element.addEventListener('import-failed', function(e) {
+          assert.instanceOf(e.detail, Error);
+          assert.equal(e.detail.message, 'No imports found in the specified group.');
+          done();
+        });
+        testEnvironment.button.click();
+      });
       test('After import triggered, element upgrades', function(done) {
         var testEnvironment = initTest();
         assert.isUndefined(testEnvironment.lazy.importLoaded);
@@ -90,8 +100,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var testEnvironment = initTest();
         testEnvironment.element.group = 'lazyFail';
 
-        testEnvironment.element.addEventListener('import-failed', function() {
+        testEnvironment.element.addEventListener('import-failed', function(e) {
           if (called) {
+            assert.instanceOf(e.detail, Error);
+            assert.equal(e.detail.message, 'One or more imports failed to load.');
+            assert.deepEqual(e.detail.importStatuses, {loaded: [], failed: ['lazy-fail-element.html']});
             done();
           } else {
             called = true; // Mark it so we can check for a second firing

--- a/test/2.0/lazy-imports_test.html
+++ b/test/2.0/lazy-imports_test.html
@@ -66,57 +66,97 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('Still resolves after second attempt to import', function(done) {
         var called = false;
         var testEnvironment = initTest();
+        sinon.stub(Polymer, 'importHref', function(url, resolve) {
+          resolve();
+        });
         testEnvironment.element.addEventListener('import-loaded', function() {
           if (called) {
-            assert.isTrue(testEnvironment.lazy.importLoaded);
             done();
           } else {
-            called = true; // mark it so we can check for a second firing
+            called = true; // Mark it so we can check for a second firing
             testEnvironment.button.click();
           }
+        });
+        testEnvironment.element.addEventListener('import-failed', function() {
+          throw new Error('fail');
         });
         testEnvironment.button.click();
       });
       test('Still rejects after second attempt to import a previously failed dependency', function(done) {
         var called = false;
-        sinon.stub(
-          Polymer, 'importHref', (url, resolve, reject) => reject());
+        sinon.stub(Polymer, 'importHref', function(url, resolve, reject) {
+          reject();
+        });
         var testEnvironment = initTest();
         testEnvironment.element.group = 'lazyFail';
 
-        testEnvironment.element.addEventListener('import-loaded', function() {
+        testEnvironment.element.addEventListener('import-failed', function() {
           if (called) {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
             done();
           } else {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
-            Polymer.importHref.restore();
-            called = true; // mark it so we can check for a second firing
+            called = true; // Mark it so we can check for a second firing
             testEnvironment.button.click();
           }
+        });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          throw new Error('fail');
         });
         testEnvironment.button.click();
       });
       test('Resolves after second attempt to import a previously failed dependency with retry flag', function(done) {
         var called = false;
-        sinon.stub(
-          Polymer, 'importHref', (url, resolve, reject) => reject());
+        sinon.stub(Polymer, 'importHref', function(url, resolve, reject) {
+          reject();
+        });
         var testEnvironment = initTest();
         testEnvironment.element.group = 'lazyFail';
         testEnvironment.element.retry = true;
 
-        testEnvironment.element.addEventListener('import-loaded', function() {
+        testEnvironment.element.addEventListener('import-failed', function() {
           if (called) {
-            assert.isTrue(testEnvironment.lazyFail.importLoaded);
-            done();
+            throw new Error('fail');
           } else {
-            assert.isUndefined(testEnvironment.lazyFail.importLoaded);
             Polymer.importHref.restore();
-            called = true; // mark it so we can check for a second firing
+            sinon.stub(Polymer, 'importHref', function(url, resolve) {
+              resolve();
+            });
+            called = true; // Mark it so we can check for a second firing
             testEnvironment.button.click();
           }
         });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          done();
+        });
         testEnvironment.button.click();
+      });
+      test('Resolves correctly if request is currently in-flight when another request is made', function(done) {
+        var called = false;
+        var resolve;
+        var promise = new Promise(function(res) {
+          resolve = res;
+        });
+        var testEnvironment = initTest();
+
+        sinon.stub(Polymer, 'importHref', function(url, res) {
+          promise.then(res);
+        });
+
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          if (called) {
+            done();
+          }
+          called = true; // Mark call and wait for second promise event
+        });
+        testEnvironment.element.addEventListener('import-failed', function() {
+          throw new Error('fail');
+        });
+
+        testEnvironment.button.click();
+        assert.isFalse(called);
+        testEnvironment.button.click();
+        assert.isFalse(called);
+
+        resolve();
       });
       test('Does not throw an exception when importing number based groups', function() {
         var testEnvironment = initTest();

--- a/test/2.0/upgrade-button.html
+++ b/test/2.0/upgrade-button.html
@@ -37,10 +37,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       buttonPressed() {
-        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then((results) => {
-          console.log(results);
-          this.dispatchEvent(new CustomEvent('import-loaded', results));
-        });
+        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(
+          (results) => {
+            console.log(results);
+            this.dispatchEvent(new CustomEvent('import-loaded', results));
+          },
+          (results) => {
+            console.log(results);
+            this.dispatchEvent(new CustomEvent('import-failed', results));
+          }
+        );
       }
     }
 

--- a/test/2.0/upgrade-button.html
+++ b/test/2.0/upgrade-button.html
@@ -28,10 +28,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       static get properties() {
         return {
           retry: Boolean,
-
           group: {
             type: String,
-            value: 'lazy'
+            value: 'lazy',
           }
         };
       }
@@ -40,11 +39,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(
           (results) => {
             console.log(results);
-            this.dispatchEvent(new CustomEvent('import-loaded', results));
+            this.dispatchEvent(new CustomEvent('import-loaded', {
+              detail: results,
+            }));
           },
           (results) => {
             console.log(results);
-            this.dispatchEvent(new CustomEvent('import-failed', results));
+            this.dispatchEvent(new CustomEvent('import-failed', {
+              detail: results,
+            }));
           }
         );
       }


### PR DESCRIPTION
Addresses #20 

Changes:

- If there are no imports found with the specified group, it will reject with empty arrays for loaded and failed.
- If there are any failed requests, it will reject with the results of the group imports.

@garlicnation @justinfagnani @rictic PTAL

**UPDATE:** Rebased onto master