### PR TITLE
Remove the paper-button in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ Then apply the `LazyImportsMixin` mixin (or `LazyImportsBehavior`) to your eleme
 ### Polymer 2.0 – LazyImportsMixin
 
 ```html
-<link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../paper-button/paper-button.html">
+<link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../lazy-imports-mixin.html">
 
 <dom-module id="upgrade-button">
   <link rel="lazy-import" group="lazy" href="lazy-element.html">
   <template>
-    <paper-button on-click="buttonPressed">Upgrade Element</paper-button>
+    <button on-tap="buttonPressed">Upgrade Element</button>
     <lazy-element>When upgraded, this element will have a red border</lazy-element>
   </template>
   <script>
@@ -50,13 +49,12 @@ Then apply the `LazyImportsMixin` mixin (or `LazyImportsBehavior`) to your eleme
 
 ```html
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-button/paper-button.html">
 <link rel="import" href="../lazy-imports-behavior.html">
 
 <dom-module id="upgrade-button">
   <link rel="lazy-import" group="lazy" href="lazy-element.html">
   <template>
-    <paper-button id="button" on-tap="buttonPressed">Upgrade Element</paper-button>
+    <button on-tap="buttonPressed">Upgrade Element</button>
     <lazy-element id="lazy">When upgraded, this element will have a red border</lazy-element>
   </template>
   <script>


### PR DESCRIPTION
I proposed to simplify a bit the README example.