### PR TITLE
Fix: broken lazy-import selector

### DIFF
--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         fromElement = Polymer.DomModule.import(callingElement.localName);
       }
 
-      var groupAttribute = group ? '[group=' + group + ']' : ':not([group])';
+      var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
       var query =
         'link' +groupAttribute+ '[rel=\'lazy-import\'][href]:not([href=\'\'])';
       var imports = fromElement.querySelectorAll(query);

--- a/test/1.x/lazy-imports_test.html
+++ b/test/1.x/lazy-imports_test.html
@@ -59,7 +59,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         testEnvironment.button.click();
       });
-
+      test('Does not throw an exception when importing number based groups', function() {
+        var testEnvironment = initTest();
+        assert.doesNotThrow(testEnvironment.element.importLazyGroup.bind(this, 404, testEnvironment.element), Error);
+      });
     });
   </script>
 </body>

--- a/test/2.0/lazy-imports_test.html
+++ b/test/2.0/lazy-imports_test.html
@@ -71,7 +71,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         testEnvironment.button.click();
       });
-
+      test('Does not throw an exception when importing number based groups', function() {
+        var testEnvironment = initTest();
+        assert.doesNotThrow(testEnvironment.element.importLazyGroup.bind(this, 404, testEnvironment.element), Error);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Error:
Uncaught (in promise) DOMException: Failed to execute 'querySelectorAll' on 'Element': 'link[group=404][rel='lazy-import'][href]:not([href=''])' is not a valid selector.