### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,10 @@
     "lazy",
     "import"
   ],
-  "main": "lazy-imports.html",
+  "main": [
+    "lazy-imports-behavior.html",
+    "lazy-imports-mixin.html"
+  ],
   "private": true,
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-        "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.0",
+        "promise-polyfill": "PolymerLabs/promise-polyfill#1 - 2",
         "web-component-tester": "Polymer/web-component-tester#^5.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },

--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,7 @@
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.2.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
@@ -39,8 +38,7 @@
       },
       "devDependencies": {
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-        "promise-polyfill": "polymerlabs/promise-polyfill#1 - 2",
-        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.0",
         "web-component-tester": "Polymer/web-component-tester#^5.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },


### PR DESCRIPTION
Update main elements & Polymer v2 dependencies.

`web-component-tester` v6.2.0 uses the `test-fixture` v3.0.0. 🎉 

<hr>

I'm not sure if we should remove the line:

`"test-fixture": "PolymerElements/test-fixture#^3.0.0",`

https://github.com/Polymer/web-component-tester/blob/master/bower.json#L37