### PR TITLE
feat(lazy-imports-import): add options.async

### DIFF
--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -30,6 +30,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Promise}
      */
     Polymer.__importLazyGroup = function(fromElement, group, options) {
+      if(!options) {
+        options = {};
+      }
       var importStatuses = {loaded: [], failed: []};
       var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
       var query =
@@ -51,13 +54,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var requestImport = function() {
           return new Promise(function(resolve, reject) {
             var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject, options && options.async);
+            importHref(resolvedUrl, resolve, reject, options.async);
           });
         };
 
         if (__importPromises.has(resolvedUrl)) {
           promise = __importPromises.get(resolvedUrl);
-          if (options && options.retry) {
+          if (options.retry) {
             promise = promise.catch(requestImport);
           }
         } else {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var requestImport = function() {
           return new Promise(function(resolve, reject) {
             var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject);
+            importHref(resolvedUrl, resolve, reject, options && options.async);
           });
         };
 

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Promise}
      */
     Polymer.__importLazyGroup = function(fromElement, group, options) {
-      if(!options) {
+      if (!options) {
         options = {};
       }
       var importStatuses = {loaded: [], failed: []};


### PR DESCRIPTION
I use `lazy-import` in production mode and need to import multi-component asynchronously to fix our loading issue.
Could you please merge this PR as soon as possible?
Thank you.

Fixed #42