### PR TITLE
New: Async option for importHref

### DIFF
--- a/lazy-imports-behavior.html
+++ b/lazy-imports-behavior.html
@@ -38,12 +38,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {string=} group The group attribute to filter on.
        * @param {HTMLElement=} fromElement The element to search for lazy
-       *                                   imports within. If no element is
-       *                                   provided, this behavior will find a
-       *                                   `dom-module` with an `id` matching
-       *                                   `this.localName`.
-       * @param {object=} options Accepts a retry flag which will force a
-       *                          retry of a previously failed import.
+       *     imports within. If no element is provided, this behavior will find
+       *     a `dom-module` with an `id` matching `this.localName`.
+       * @param {{async: boolean|undefined, retry: boolean|undefined}=} options
+       *     The async flag will use an asynchronous HTML Import.
+       *     The retry flag will force a retry of a previously failed import.
        * @return {Promise}
        */
       importLazyGroup: function(group, fromElement, options) {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -25,11 +25,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {HTMLElement} fromElement The element to search for lazy imports
      *                                  within.
      * @param {string=} group The group attribute to filter on.
-     * @param {object=} options Accepts a retry flag which will force a
-     *                          retry of a previously failed import.
+     * @param {{async: boolean|undefined, retry: boolean|undefined}=} options
+     *     The async flag will use an asynchronous HTML Import.
+     *     The retry flag will force a retry of a previously failed import.
      * @return {Promise}
      */
     Polymer.__importLazyGroup = function(fromElement, group, options) {
+      options = options || {};
       var importStatuses = {loaded: [], failed: []};
       var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
       var query =
@@ -51,13 +53,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var requestImport = function() {
           return new Promise(function(resolve, reject) {
             var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject);
+            importHref(resolvedUrl, resolve, reject, options.async);
           });
         };
 
         if (__importPromises.has(resolvedUrl)) {
           promise = __importPromises.get(resolvedUrl);
-          if (options && options.retry) {
+          if (options.retry) {
             promise = promise.catch(requestImport);
           }
         } else {

--- a/lazy-imports-mixin.html
+++ b/lazy-imports-mixin.html
@@ -33,12 +33,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          *
          * @param {string=} group The group attribute to filter on.
          * @param {HTMLElement=} fromElement The element to search for lazy
-         *                                   imports within. If no element is
-         *                                   provided, this mixin will find a
-         *                                   `dom-module` with an `id` matching
-         *                                   `this.localName`.
-         * @param {object=} options Accepts a retry flag which will force a
-         *                          retry of a previously failed import.
+         *     imports within. If no element is provided, this behavior will find
+         *     a `dom-module` with an `id` matching `this.localName`.
+         * @param {{async: boolean|undefined, retry: boolean|undefined}=} options
+         *     The async flag will use an asynchronous HTML Import.
+         *     The retry flag will force a retry of a previously failed import.
          * @return {Promise}
          */
         importLazyGroup(group, fromElement, options) {

--- a/test/1.x/lazy-imports_test.html
+++ b/test/1.x/lazy-imports_test.html
@@ -58,11 +58,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         testEnvironment.button.click();
       });
+      test('Handles async option being passed in', function(done) {
+        var testEnvironment = initTest();
+        testEnvironment.element.optAsync = true;
+        sinon.stub(
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject, optAsync) {
+            assert.isTrue(optAsync);
+          });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          assert.isTrue(testEnvironment.lazy.importLoaded);
+          (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
+          done();
+        });
+        testEnvironment.button.click();
+      });
       test('Still resolves after second attempt to import', function(done) {
         var called = false;
         var testEnvironment = initTest();
         sinon.stub(
-          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve) {
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject, optAsync) {
+            assert.isUndefined(optAsync);
             resolve();
           });
         testEnvironment.element.addEventListener('import-loaded', function() {
@@ -85,7 +100,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         testEnvironment.element.group = 'lazyFail';
 
         sinon.stub(
-          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject) {
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject, optAsync) {
+            assert.isUndefined(optAsync);
             reject();
           });
 
@@ -113,7 +129,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         testEnvironment.element.retry = true;
 
         sinon.stub(
-          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject) {
+          (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject, optAsync) {
+            assert.isUndefined(optAsync);
             reject();
           });
 
@@ -123,7 +140,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } else {
             (Polymer.Element ? Polymer : testEnvironment.element).importHref.restore();
             sinon.stub(
-              (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve) {
+              (Polymer.Element ? Polymer : testEnvironment.element), 'importHref', function(url, resolve, reject, optAsync) {
+                assert.isUndefined(optAsync);
                 resolve();
               });
             called = true; // mark it so we can check for a second firing

--- a/test/1.x/upgrade-button.html
+++ b/test/1.x/upgrade-button.html
@@ -28,8 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       behaviors: [Polymer.LazyImportsBehavior],
 
       properties: {
+        optAsync: Boolean,
         retry: Boolean,
-
         group: {
           type: String,
           value: 'lazy',
@@ -37,7 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       buttonPressed: function(e) {
-        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(
+        this.importLazyGroup(this.group, undefined, {async: this.optAsync, retry: this.retry}).then(
           function(results) {
             console.log(results);
             this.fire('import-loaded', results);

--- a/test/2.0/lazy-imports_test.html
+++ b/test/2.0/lazy-imports_test.html
@@ -73,10 +73,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         testEnvironment.button.click();
       });
+      test('Handles async option being passed in', function(done) {
+        var testEnvironment = initTest();
+        testEnvironment.element.optAsync = true;
+        sinon.stub(Polymer, 'importHref', function(url, resolve, reject, optAsync) {
+          assert.isTrue(optAsync);
+        });
+        testEnvironment.element.addEventListener('import-loaded', function() {
+          assert.isTrue(testEnvironment.lazy.importLoaded);
+          Polymer.importHref.restore();
+          done();
+        });
+        testEnvironment.button.click();
+      });
       test('Still resolves after second attempt to import', function(done) {
         var called = false;
         var testEnvironment = initTest();
-        sinon.stub(Polymer, 'importHref', function(url, resolve) {
+        sinon.stub(Polymer, 'importHref', function(url, resolve, reject, optAsync) {
+          assert.isUndefined(optAsync);
           resolve();
         });
         testEnvironment.element.addEventListener('import-loaded', function() {
@@ -94,7 +108,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
       test('Still rejects after second attempt to import a previously failed dependency', function(done) {
         var called = false;
-        sinon.stub(Polymer, 'importHref', function(url, resolve, reject) {
+        sinon.stub(Polymer, 'importHref', function(url, resolve, reject, optAsync) {
+          assert.isUndefined(optAsync);
           reject();
         });
         var testEnvironment = initTest();
@@ -130,7 +145,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             throw new Error('fail');
           } else {
             Polymer.importHref.restore();
-            sinon.stub(Polymer, 'importHref', function(url, resolve) {
+            sinon.stub(Polymer, 'importHref', function(url, resolve, reject, optAsync) {
+              assert.isUndefined(optAsync);
               resolve();
             });
             called = true; // Mark it so we can check for a second firing

--- a/test/2.0/upgrade-button.html
+++ b/test/2.0/upgrade-button.html
@@ -27,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       static get properties() {
         return {
+          optAsync: Boolean,
           retry: Boolean,
           group: {
             type: String,
@@ -36,7 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       buttonPressed() {
-        this.importLazyGroup(this.group, undefined, {retry: this.retry}).then(
+        this.importLazyGroup(this.group, undefined, {async: this.optAsync, retry: this.retry}).then(
           (results) => {
             console.log(results);
             this.dispatchEvent(new CustomEvent('import-loaded', {


### PR DESCRIPTION
Supersedes #43 
Closes #42 

Allows the `async` flag to be passed through to the `importHref` call using the `options` object.

/cc @AliMD

@justinfagnani @rictic Any thoughts on this?