### PR TITLE
Refactor: Attempt to increase performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
-language: node_js
-sudo: required
 dist: trusty
+sudo: false
+language: node_js
 node_js: stable
 cache:
   directories:
     - node_modules
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 install:
-  - npm install -g bower polymer-cli eslint eslint-plugin-html eslint-config-google
+  - npm install -g polymer-cli eslint eslint-plugin-html eslint-config-google
   - polymer install --variants
 before_script:
   - polymer lint --rules polymer-2-hybrid --input *.html
   - eslint -c .eslintrc-es5.json lazy-imports-import.html lazy-imports-behavior.html
   - eslint -c .eslintrc.json lazy-imports-mixin.html
 script:
-  - xvfb-run polymer test
+  - polymer test
 #  - >-
 #    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
 #    fi

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -1,3 +1,4 @@
+
 <!--
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
@@ -12,7 +13,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    var __importPromises = new Map();
+    const __lazyImports = new Map();
+
+    function requestImport(link, fromElement, importStatuses) {
+      const href = link.getAttribute('href');
+      link.promise = new Promise(function(resolve, reject) {
+        const importHref = Polymer.importHref || fromElement.importHref;
+        importHref(fromElement.resolveUrl(href), resolve, reject);
+      });
+      return link.promise.then(
+        function onLoad() {
+          return importStatuses.loaded.push({loaded: href});
+        },
+        function onFail() {
+          return importStatuses.failed.push({failed: href});
+        }
+      )
+    }
 
     /**
      * Calls `Polymer.Base.importHref` for each `<link rel="lazy-import"` in
@@ -30,71 +47,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Promise}
      */
     Polymer.__importLazyGroup = function(fromElement, group, options) {
-      var importStatuses = {loaded: [], failed: []};
-      var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
-      var query =
-        'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
+      const query =
+        'link[rel=\'lazy-import\'][href]:not([href=\'\'])';
 
-      var links =
-        Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
+      if (!__lazyImports.get(fromElement)) {
+        const links =
+        Array.from(Polymer.DomModule.import(fromElement.localName).querySelectorAll(query));
+        __lazyImports.set(fromElement, links.reduce((obj, link) => {
+          const group = link.getAttribute('group');
+          if (!obj[group]) {
+            obj[group] = [];
+          }
+          obj[group].push(link);
+          return obj;
+        }, {}));
+      }
 
-      if (links.length < 1) {
+      const groupLinks = __lazyImports.get(fromElement)[group];
+      if (groupLinks.length < 1) {
         return Promise.reject(
           new Error('No imports found in the specified group.'));
       }
 
-      var requestPromises = Array.from(links).map(function(link) {
-        var promise;
-        var href = link.getAttribute('href');
-        var resolvedUrl = fromElement.resolveUrl(href);
+      const __importStatuses = {loaded: [], failed: []};
+      const requestPromises = groupLinks.map(function(link) {
+        let promise;
 
-        var requestImport = function() {
-          return new Promise(function(resolve, reject) {
-            var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject);
-          });
-        };
-
-        if (__importPromises.has(resolvedUrl)) {
-          promise = __importPromises.get(resolvedUrl);
+        if (link.promise) {
+          promise = link.promise;
           if (options && options.retry) {
-            promise = promise.catch(requestImport);
+            promise = promise.catch(requestImport.bind(this, link, fromElement, __importStatuses));
           }
         } else {
-          promise = requestImport();
+          promise = requestImport(link, fromElement, __importStatuses);
         }
 
-        __importPromises.set(resolvedUrl, promise);
-
-        return promise.then(
-          function onLoad() {
-            return {loaded: href};
-          },
-          function onFail() {
-            return {failed: href};
-          }
-        );
+        return promise;
       });
-
-      return Promise.all(requestPromises).then(function(importRequests) {
-        importStatuses = importRequests.reduce(function(requests, nextRequest) {
-          if (nextRequest.loaded) {
-            requests.loaded.push(nextRequest.loaded);
-          }
-
-          if (nextRequest.failed) {
-            requests.failed.push(nextRequest.failed);
-          }
-
-          return requests;
-        }, importStatuses);
-
-        if (importStatuses.failed.length > 0) {
+      return Promise.all(requestPromises).then(function() {
+        if (__importStatuses.failed.length > 0) {
           const error = new Error('One or more imports failed to load.');
-          error.importStatuses = importStatuses;
+          error.importStatuses = __importStatuses;
           throw error;
         } else {
-          return importStatuses;
+          return __importStatuses;
         }
       });
     };

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const href = link.getAttribute('href');
       link.promise = new Promise(function(resolve, reject) {
         const importHref = Polymer.importHref || fromElement.importHref;
-        importHref(fromElement.resolveUrl(href), resolve, reject, true);
+        importHref(fromElement.resolveUrl(href), resolve, reject);
       });
       return link.promise.then(
         function onLoad() {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -12,7 +12,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    var __importPromises = new Map();
+    const __lazyImports = new Map();
+
+
+    /**
+     * Handles the actual import of each document and reporting the status
+     *
+     * @param {HTMLElement} link The link tag to import a document for
+     * @param {HTMLElement} fromElement The element to search for lazy imports
+     *                                  within.
+     * @return {Promise}
+     */
+    function __requestImport(link, fromElement) {
+      return link.promise = new Promise(function(resolve, reject) {
+        const importHref = Polymer.importHref || fromElement.importHref;
+        const resolvedUrl = fromElement.resolveUrl(link.getAttribute('href'));
+        importHref(resolvedUrl, resolve, reject, true);
+      });
+    }
 
     /**
      * Calls `Polymer.Base.importHref` for each `<link rel="lazy-import"` in
@@ -30,65 +47,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Promise}
      */
     Polymer.__importLazyGroup = function(fromElement, group, options) {
-      var importStatuses = {loaded: [], failed: []};
-      var groupAttribute = group ? '[group="' + group + '"]' : ':not([group])';
-      var query =
-        'link' + groupAttribute + '[rel=\'lazy-import\'][href]:not([href=\'\'])';
+      const query =
+        'link[rel=\'lazy-import\'][href]:not([href=\'\'])';
 
-      var links =
-        Polymer.DomModule.import(fromElement.localName).querySelectorAll(query);
+      if (!__lazyImports.get(fromElement)) {
+        const links = Array.from(
+          Polymer.DomModule.import(fromElement.localName)
+          .querySelectorAll(query));
 
-      if (links.length < 1) {
+        __lazyImports.set(fromElement, links.reduce(function(obj, link) {
+          const group = link.getAttribute('group');
+          if (!obj[group]) {
+            obj[group] = [];
+          }
+          obj[group].push(link);
+          return obj;
+        }, {}));
+      }
+
+      // Exit early if there is no associcated group
+      const groupLinks = __lazyImports.get(fromElement)[group];
+      if (!groupLinks) {
         return Promise.reject(
           new Error('No imports found in the specified group.'));
       }
 
-      var requestPromises = Array.from(links).map(function(link) {
-        var promise;
-        var href = link.getAttribute('href');
-        var resolvedUrl = fromElement.resolveUrl(href);
+      const importStatuses = {loaded: [], failed: []};
+      const requestPromises = groupLinks.map(function(link) {
+        let promise;
 
-        var requestImport = function() {
-          return new Promise(function(resolve, reject) {
-            var importHref = Polymer.importHref || fromElement.importHref;
-            importHref(resolvedUrl, resolve, reject);
-          });
-        };
-
-        if (__importPromises.has(resolvedUrl)) {
-          promise = __importPromises.get(resolvedUrl);
+        // Use existing promise if available
+        if (link.promise) {
+          promise = link.promise;
           if (options && options.retry) {
-            promise = promise.catch(requestImport);
+            promise = promise.catch(function() {
+              return __requestImport(link, fromElement, importStatuses);
+            });
           }
         } else {
-          promise = requestImport();
+          promise = __requestImport(link, fromElement, importStatuses);
         }
 
-        __importPromises.set(resolvedUrl, promise);
+        // Store request promise
+        link.promise = promise;
 
+        // Make all promises resolve for final output
+        const href = link.getAttribute('href');
         return promise.then(
           function onLoad() {
-            return {loaded: href};
+            return importStatuses.loaded.push(href);
           },
           function onFail() {
-            return {failed: href};
+            return importStatuses.failed.push(href);
           }
         );
       });
-
-      return Promise.all(requestPromises).then(function(importRequests) {
-        importStatuses = importRequests.reduce(function(requests, nextRequest) {
-          if (nextRequest.loaded) {
-            requests.loaded.push(nextRequest.loaded);
-          }
-
-          if (nextRequest.failed) {
-            requests.failed.push(nextRequest.failed);
-          }
-
-          return requests;
-        }, importStatuses);
-
+      return Promise.all(requestPromises).then(function() {
         if (importStatuses.failed.length > 0) {
           const error = new Error('One or more imports failed to load.');
           error.importStatuses = importStatuses;

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -69,28 +69,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           new Error('No imports found in the specified group.'));
       }
 
-      const __importStatuses = {loaded: [], failed: []};
+      const importStatuses = {loaded: [], failed: []};
       const requestPromises = groupLinks.map(function(link) {
         let promise;
 
         if (link.promise) {
           promise = link.promise;
           if (options && options.retry) {
-            promise = promise.catch(requestImport.bind(this, link, fromElement, __importStatuses));
+            promise = promise.catch(requestImport.bind(this, link, fromElement, importStatuses));
           }
         } else {
-          promise = requestImport(link, fromElement, __importStatuses);
+          promise = requestImport(link, fromElement, importStatuses);
         }
 
         return promise;
       });
       return Promise.all(requestPromises).then(function() {
-        if (__importStatuses.failed.length > 0) {
+        if (importStatuses.failed.length > 0) {
           const error = new Error('One or more imports failed to load.');
-          error.importStatuses = __importStatuses;
+          error.importStatuses = importStatuses;
           throw error;
         } else {
-          return __importStatuses;
+          return importStatuses;
         }
       });
     };

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -81,11 +81,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           promise = link.promise;
           if (options && options.retry) {
             promise = promise.catch(function() {
-              return __requestImport(link, fromElement, importStatuses);
+              return __requestImport(link, fromElement);
             });
           }
         } else {
-          promise = __requestImport(link, fromElement, importStatuses);
+          promise = __requestImport(link, fromElement);
         }
 
         // Store request promise

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -19,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const href = link.getAttribute('href');
       link.promise = new Promise(function(resolve, reject) {
         const importHref = Polymer.importHref || fromElement.importHref;
-        importHref(fromElement.resolveUrl(href), resolve, reject);
+        importHref(fromElement.resolveUrl(href), resolve, reject, true);
       });
       return link.promise.then(
         function onLoad() {

--- a/lazy-imports-import.html
+++ b/lazy-imports-import.html
@@ -1,4 +1,3 @@
-
 <!--
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
@@ -15,7 +14,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     const __lazyImports = new Map();
 
-    function requestImport(link, fromElement, importStatuses) {
+
+    /**
+     * Handles the actual import of each document and reporting the status
+     *
+     * @param {HTMLElement} link The link tag to import a document for
+     * @param {HTMLElement} fromElement The element to search for lazy imports
+     *                                  within.
+     * @param {object} importStatuses The object to report the status of each
+     *                                  import to.
+     * @return {Promise}
+     */
+    function __requestImport(link, fromElement, importStatuses) {
       const href = link.getAttribute('href');
       link.promise = new Promise(function(resolve, reject) {
         const importHref = Polymer.importHref || fromElement.importHref;
@@ -28,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         function onFail() {
           return importStatuses.failed.push({failed: href});
         }
-      )
+      );
     }
 
     /**
@@ -52,8 +62,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (!__lazyImports.get(fromElement)) {
         const links =
-        Array.from(Polymer.DomModule.import(fromElement.localName).querySelectorAll(query));
-        __lazyImports.set(fromElement, links.reduce((obj, link) => {
+        Array.from(
+          Polymer.DomModule.import(fromElement.localName)
+          .querySelectorAll(query));
+
+        __lazyImports.set(fromElement, links.reduce(function(obj, link) {
           const group = link.getAttribute('group');
           if (!obj[group]) {
             obj[group] = [];
@@ -76,10 +89,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (link.promise) {
           promise = link.promise;
           if (options && options.retry) {
-            promise = promise.catch(requestImport.bind(this, link, fromElement, importStatuses));
+            promise = promise.catch(function() {
+              return __requestImport(link, fromElement, importStatuses);
+            });
           }
         } else {
-          promise = requestImport(link, fromElement, importStatuses);
+          promise = __requestImport(link, fromElement, importStatuses);
         }
 
         return promise;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,16 @@
+{
+  "plugins": {
+    "local": {
+      "browserOptions": {
+        "chrome": [
+          "headless",
+          "disable-gpu",
+          "no-sandbox"
+        ],
+        "firefox": [
+          "-headless"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
These changes were made when doing some profiling for PSK. https://github.com/Polymer/polymer-starter-kit/pull/998
https://gist.github.com/stramel/82509631e3e187760d4eb916f1ec787a

**Key things:**

- ~Switch `async` to `true` by default.~
- Switch to using `const` and `let` instead of `var`.
- Cache each element's `lazy-import`s
- Do less until it is necessary, exit early
- Less looping/reducing of the `lazy-import`s array.

/cc @justinfagnani 

Should also address #42 

**UPDATE:** After discussion, we decided to not use `async` for dynamically added imports.